### PR TITLE
Add web framework and PostgreSQL dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi
 uvicorn[standard]
-asyncpg
 pydantic-settings
 python-dotenv
 tenacity
@@ -9,3 +8,7 @@ loguru
 pytest
 httpx[http2]
 alembic
+Flask
+flask-cors
+requests
+psycopg2-binary


### PR DESCRIPTION
## Summary
- include Flask, flask-cors, requests, and psycopg2-binary in requirements
- drop unused asyncpg dependency

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'\nimport flask, flask_cors, requests, psycopg2\nprint('imports successful')\nPY`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab894f5b788332996a2c72ed662bed