### PR TITLE
Allow messages without conversation IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,7 +76,7 @@ class MessageOut(BaseModel):
 
 class MessageRow(BaseModel):
     id: int
-    conversation_id: str
+    conversation_id: Optional[str]
     sender: Optional[str]
     app: Optional[str]
     message: Optional[str]


### PR DESCRIPTION
## Summary
- Allow MessageRow to represent messages that lack a conversation ID
- Confirm search and conversation endpoints gracefully handle missing conversation IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab8a07973c8332b964b98af6085d0b