### PR TITLE
Add /ack-prompt endpoint to server and update docs/tests

### DIFF
--- a/myGPT usage.md
+++ b/myGPT usage.md
@@ -70,6 +70,7 @@ else:
 |--------|----------|-------------|
 | `POST` | `/send-prompt` | Send a prompt from Python |
 | `GET` | `/get-prompt` | Get prompt (userscript) |
+| `POST` | `/ack-prompt` | Acknowledge prompt (clears stored prompt) |
 | `POST` | `/process-response` | Receive AI response (userscript) |
 | `GET` | `/status` | Server status |
 | `GET` | `/history` | Response history |

--- a/server.py
+++ b/server.py
@@ -62,6 +62,20 @@ def get_prompt():
     
     return jsonify({'prompt': prompt_to_send})
 
+
+@app.route('/ack-prompt', methods=['POST'])
+def ack_prompt():
+    """Acknowledge the prompt and clear it if present."""
+    global stored_prompt
+
+    if stored_prompt is not None:
+        logger.info('Prompt acknowledged and cleared')
+    else:
+        logger.info('Ack called but no prompt stored')
+
+    stored_prompt = None
+    return jsonify({'status': 'success'})
+
 @app.route('/process-response', methods=['POST'])
 def process_response():
     """Receive the AI response from the userscript."""
@@ -201,6 +215,7 @@ if __name__ == '__main__':
     print('Available endpoints:')
     print('  POST /send-prompt    - Send a prompt from Python')
     print('  GET  /get-prompt     - Get prompt (userscript)')
+    print('  POST /ack-prompt     - Acknowledge prompt')
     print('  POST /process-response - Receive AI response (userscript)')
     print('  POST /test-response  - Generate test response (for testing)')
     print('  GET  /status         - Server status')

--- a/test.py
+++ b/test.py
@@ -111,8 +111,6 @@ class TestFlaskServer:
 
         # 4. Acknowledge the prompt (This endpoint only exists in the fixed server.py)
         ack_response = requests.post(f"{FLASK_SERVER_URL}/ack-prompt", headers=HEADERS)
-        if ack_response.status_code == 404:
-            pytest.skip("Skipping ack test: /ack-prompt not found. You may be running the original server.py.")
         assert ack_response.status_code == 200
         assert ack_response.json()['status'] == 'success'
 


### PR DESCRIPTION
## Summary
- implement `/ack-prompt` endpoint that clears stored prompt and reports success
- document new endpoint in myGPT usage guide
- update tests to exercise the new acknowledgement route

## Testing
- `pytest test.py -q` *(fails: One or more servers failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a096bac833298bfac91bdc76dd9