### PR TITLE
Launch servers concurrently with updated ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # oldAIagent
 old ai agent version
+
+## Services
+
+- **Flask service** (`server.py`) runs on port `5000`.
+- **FastAPI service** (`app.py`) runs on port `8000`.
+
+Use `python main.py` to launch both servers simultaneously.

--- a/app.py
+++ b/app.py
@@ -218,5 +218,5 @@ def match_context(text: str, match_threshold: float = 0.75, match_count: int = 5
 
 if __name__ == "__main__":
     import uvicorn
-    log.info("Starting API on 0.0.0.0:8001")
-    uvicorn.run("app:app", host="0.0.0.0", port=8001, reload=True)
+    log.info("Starting API on 0.0.0.0:8000")
+    uvicorn.run("app:app", host="0.0.0.0", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- Start FastAPI via uvicorn on port 8000 and Flask server via `python server.py` in `run_both`
- Stream both subprocess outputs concurrently using threads
- Document new port assignments for Flask (5000) and FastAPI (8000)

## Testing
- `pytest test.py -q` *(fails: One or more servers failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a0c8b348332af6f909a3d3d9e96