### PR TITLE
Use dev API key in tests and document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ old ai agent version
 - **FastAPI service** (`app.py`) runs on port `8000`.
 
 Use `python main.py` to launch both servers simultaneously.
+
+## API Key
+
+The FastAPI service requires a simple header-based API key. For development
+and automated tests, use the canonical key `dev-api-key` by including it in the
+`X-API-KEY` header of each request. The server can be configured to expect a
+different key by setting the `API_KEY` environment variable before startup.

--- a/test.py
+++ b/test.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 # --- Configuration ---
 FLASK_SERVER_URL = "http://localhost:5000"
 FASTAPI_SERVER_URL = "http://localhost:8000"
-# This API key must match the one in your fixed server.py
-API_KEY = "your-secret-api-key"
+# The FastAPI app expects this development key by default.
+API_KEY = "dev-api-key"
 HEADERS = {"X-API-KEY": API_KEY}
 
 # --- Helper function to wait for servers ---


### PR DESCRIPTION
## Summary
- Align tests with application default by using the `dev-api-key` value for `X-API-KEY`.
- Document the canonical development API key in the README.

## Testing
- `pip install -r requirements.txt`
- `pytest test.py` *(fails: One or more servers failed to start)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8d6c64dc8332b7dc2c97f94ad54b