### PR TITLE
Use thread-safe in-memory storage for Flask prompt server

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 import logging
 from datetime import datetime
+from threading import Lock
 
 # Configure logging
 logging.basicConfig(
@@ -20,32 +21,88 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 CORS(app)  # Enable CORS for all routes
 
-# Global variables
-stored_prompt = None
-response_history = []
+# In-memory datastore protected by a lock
+
+
+class InMemoryStore:
+    """Thread-safe storage for prompts and responses."""
+
+    def __init__(self):
+        self._lock = Lock()
+        self._prompt = None
+        self._responses = []
+
+    # Prompt operations -------------------------------------------------
+    def set_prompt(self, prompt: str) -> None:
+        with self._lock:
+            self._prompt = prompt
+
+    def pop_prompt(self):
+        """Return and clear the stored prompt."""
+        with self._lock:
+            prompt = self._prompt
+            self._prompt = None
+            return prompt
+
+    def clear_prompt(self) -> None:
+        with self._lock:
+            self._prompt = None
+
+    def has_prompt(self) -> bool:
+        with self._lock:
+            return self._prompt is not None
+
+    # Response history operations --------------------------------------
+    def add_response(self, timestamp: str, response: str) -> None:
+        with self._lock:
+            self._responses.append({'timestamp': timestamp, 'response': response})
+            if len(self._responses) > 10:
+                self._responses.pop(0)
+
+    def get_responses(self):
+        with self._lock:
+            return list(self._responses)
+
+    def response_count(self) -> int:
+        with self._lock:
+            return len(self._responses)
+
+    def recent_responses(self, n: int = 5):
+        with self._lock:
+            return [
+                {'timestamp': r['timestamp'], 'length': len(r['response'])}
+                for r in self._responses[-n:]
+            ]
+
+    def clear_all(self) -> None:
+        with self._lock:
+            self._prompt = None
+            self._responses.clear()
+
+
+store = InMemoryStore()
 
 @app.route('/send-prompt', methods=['POST'])
 def send_prompt():
     """Receive a prompt from a Python script."""
-    global stored_prompt
-    
+
     try:
         data = request.get_json()
         if not data or 'prompt' not in data:
             return jsonify({'error': 'No prompt provided'}), 400
-        
+
         prompt = data['prompt']
-        stored_prompt = prompt
-        
+        store.set_prompt(prompt)
+
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         logger.info(f'Prompt received and stored [{timestamp}]: "{prompt}"')
-        
+
         return jsonify({
             'status': 'success',
             'message': 'Prompt received',
             'timestamp': timestamp
         })
-        
+
     except Exception as e:
         logger.error(f'Error processing prompt: {str(e)}')
         return jsonify({'error': 'Internal server error'}), 500
@@ -53,51 +110,40 @@ def send_prompt():
 @app.route('/get-prompt', methods=['GET'])
 def get_prompt():
     """Send the stored prompt to the userscript and clear it."""
-    global stored_prompt
-    
-    prompt_to_send = stored_prompt
+
+    prompt_to_send = store.pop_prompt()
     if prompt_to_send:
-        stored_prompt = None
         logger.info(f'Prompt sent to userscript: "{prompt_to_send}"')
-    
+
     return jsonify({'prompt': prompt_to_send})
 
 
 @app.route('/ack-prompt', methods=['POST'])
 def ack_prompt():
     """Acknowledge the prompt and clear it if present."""
-    global stored_prompt
 
-    if stored_prompt is not None:
+    if store.has_prompt():
         logger.info('Prompt acknowledged and cleared')
     else:
         logger.info('Ack called but no prompt stored')
 
-    stored_prompt = None
+    store.clear_prompt()
     return jsonify({'status': 'success'})
 
 @app.route('/process-response', methods=['POST'])
 def process_response():
     """Receive the AI response from the userscript."""
-    global response_history
-    
+
     try:
         data = request.get_json()
         if not data or 'response' not in data:
             return jsonify({'error': 'No response provided'}), 400
-        
+
         response = data['response']
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        
+
         # Store response in history
-        response_history.append({
-            'timestamp': timestamp,
-            'response': response
-        })
-        
-        # Keep only last 10 responses
-        if len(response_history) > 10:
-            response_history.pop(0)
+        store.add_response(timestamp, response)
         
         # Print the response
         print('\n' + '='*60)
@@ -122,16 +168,15 @@ def process_response():
 @app.route('/test-response', methods=['POST'])
 def generate_test_response():
     """Generate a test response for testing purposes (without userscript)."""
-    global stored_prompt, response_history
-    
+
     try:
         data = request.get_json()
         if not data or 'prompt' not in data:
             return jsonify({'error': 'No prompt provided'}), 400
-        
+
         prompt = data['prompt']
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        
+
         # Generate a simple test response based on the prompt
         if "meeting" in prompt.lower() or "confirm" in prompt.lower():
             test_response = "Yes, the meeting is confirmed for 10 AM tomorrow. Looking forward to it!"
@@ -143,19 +188,12 @@ def generate_test_response():
             test_response = "Based on the recent messages, here's a brief summary: Several questions were asked about meetings and proposals. All messages require responses."
         else:
             test_response = "Thank you for your message. I'll get back to you soon."
-        
+
         # Store response in history
-        response_history.append({
-            'timestamp': timestamp,
-            'response': test_response
-        })
-        
-        # Keep only last 10 responses
-        if len(response_history) > 10:
-            response_history.pop(0)
+        store.add_response(timestamp, test_response)
         
         logger.info(f'Test response generated: {len(test_response)} chars')
-        
+
         return jsonify({
             'status': 'success',
             'message': 'Test response generated',
@@ -163,7 +201,7 @@ def generate_test_response():
             'response': test_response,
             'response_length': len(test_response)
         })
-        
+
     except Exception as e:
         logger.error(f'Error generating test response: {str(e)}')
         return jsonify({'error': 'Internal server error'}), 500
@@ -174,33 +212,26 @@ def get_status():
     return jsonify({
         'status': 'running',
         'timestamp': datetime.now().isoformat(),
-        'stored_prompt': stored_prompt is not None,
-        'response_count': len(response_history),
-        'recent_responses': [
-            {
-                'timestamp': r['timestamp'],
-                'length': len(r['response'])
-            }
-            for r in response_history[-5:]  # Last 5 responses
-        ]
+        'stored_prompt': store.has_prompt(),
+        'response_count': store.response_count(),
+        'recent_responses': store.recent_responses(),
     })
 
 @app.route('/history', methods=['GET'])
 def get_history():
     """Get response history."""
+    responses = store.get_responses()
     return jsonify({
-        'total_responses': len(response_history),
-        'responses': response_history
+        'total_responses': len(responses),
+        'responses': responses
     })
 
 @app.route('/clear', methods=['POST'])
 def clear_data():
     """Clear stored prompt and response history."""
-    global stored_prompt, response_history
-    
-    stored_prompt = None
-    response_history.clear()
-    
+
+    store.clear_all()
+
     logger.info('Stored prompt and response history cleared')
     return jsonify({
         'status': 'success',


### PR DESCRIPTION
## Summary
- Replace global prompt/response globals with thread-safe `InMemoryStore`
- Update `/send-prompt`, `/get-prompt`, `/ack-prompt`, `/process-response`, `/history` and related endpoints to use datastore

## Testing
- `pytest test.py -q` *(fails: RuntimeError: One or more servers failed to start.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8db3e2a08332b380cc99ae226f18