### PR TITLE
Add follow-up task tracking and reply suggestion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,31 @@ The FastAPI service now runs a background scheduler powered by
 Create summarization tasks with the new CRUD endpoints under `/tasks`
 and the scheduler will fill in the `summary` field once processed.
 
+## Follow-up Task Detection
+
+Incoming messages sent to `POST /messages` are now scanned for follow-up
+phrases such as "please", "can you" or "todo". Detected tasks are stored
+in a dedicated `followup_tasks` table with a default `pending` status so
+they can be reviewed or acted on later.
+
+## Reply Suggestions
+
+Generate proposed replies for any conversation with the new
+`POST /suggestions` endpoint. The service gathers the conversation
+history, forwards it to the configured myGPT service and returns a list
+of reply suggestions.
+
+Example:
+
+```bash
+curl -X POST http://localhost:8000/suggestions \
+  -H "X-API-Key: $API_KEY" \
+  -d '{"conversation_id": "123"}'
+```
+
+Optional environment variables `MYGPT_API_URL` and `MYGPT_API_KEY` may be
+set to point at a running myGPT instance.
+
 ### Configuration
 
 APScheduler runs with in-memory settings and requires no additional
@@ -88,6 +113,3 @@ The FastAPI service requires a simple header-based API key. For development
 and automated tests, use the canonical key `dev-api-key` by including it in the
 `X-API-KEY` header of each request. The server can be configured to expect a
 different key by setting the `API_KEY` environment variable before startup.
-
-#>>>>>>> main
-#>>>>>>> main

--- a/tests/test_followup_and_suggestions.py
+++ b/tests/test_followup_and_suggestions.py
@@ -1,0 +1,119 @@
+import os
+import sys
+from contextlib import contextmanager
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+from fastapi.testclient import TestClient
+
+
+def test_detect_followup_tasks():
+    text = "Please review the report and send feedback."
+    tasks = app.detect_followup_tasks(text)
+    assert any("review" in t.lower() for t in tasks)
+
+
+class FakeCursor:
+    def __init__(self, data):
+        self.data = data
+        self.fetchone_result = None
+        self.result = []
+
+    def execute(self, sql, params=None):
+        sql = sql.strip().lower()
+        if sql.startswith("insert into chat"):
+            _id = len(self.data["Chat"]) + 1
+            sender, app_name, message, conv_id = params
+            self.data["Chat"].append({
+                "id": _id,
+                "conversation_id": conv_id,
+                "sender": sender,
+                "app": app_name,
+                "message": message,
+            })
+            self.fetchone_result = (_id, conv_id, "now")
+        elif sql.startswith("insert into followup_tasks"):
+            conv_id, task = params
+            self.data["followup_tasks"].append({"conversation_id": conv_id, "task": task})
+        elif sql.startswith("select sender, message from chat"):
+            conv_id = params[0]
+            self.result = [
+                (m["sender"], m["message"]) for m in self.data["Chat"] if m["conversation_id"] == conv_id
+            ]
+        else:
+            self.result = []
+
+    def fetchone(self):
+        return self.fetchone_result
+
+    def fetchall(self):
+        return self.result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, data):
+        self.data = data
+
+    def cursor(self):
+        return FakeCursor(self.data)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+@contextmanager
+def fake_db(data):
+    yield FakeConnection(data)
+
+
+def test_create_message_stores_tasks(monkeypatch):
+    data = {"Chat": [], "followup_tasks": []}
+
+    def _fake_db():
+        return fake_db(data)
+
+    monkeypatch.setattr(app, "db", _fake_db)
+    msg = app.MessageIn(sender="alice", app="sms", message="Please call Bob", conversation_id="1")
+    app.create_message(msg)
+    assert len(data["followup_tasks"]) == 1
+    assert "call" in data["followup_tasks"][0]["task"].lower()
+
+
+def test_suggestions_endpoint(monkeypatch):
+    data = {
+        "Chat": [
+            {"id": 1, "conversation_id": "1", "sender": "alice", "message": "Hello"},
+            {"id": 2, "conversation_id": "1", "sender": "bob", "message": "Hi"},
+        ],
+        "followup_tasks": [],
+    }
+
+    def _fake_db():
+        return fake_db(data)
+
+    monkeypatch.setattr(app, "db", _fake_db)
+
+    class FakeAPI:
+        def generate_test_response(self, prompt: str):
+            return {"response": "Sure\nLet's do it\nNo thanks"}
+
+    monkeypatch.setattr(app, "myGPTAPI", FakeAPI)
+
+    client = TestClient(app.app)
+    resp = client.post(
+        "/suggestions",
+        json={"conversation_id": "1"},
+        headers={"X-API-Key": app.API_KEY_EXPECTED},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["suggestions"][0].startswith("Sure")


### PR DESCRIPTION
## Summary
- Detect follow-up actions in incoming messages and store them in a new `followup_tasks` table
- Provide `POST /suggestions` endpoint that uses myGPT to propose replies based on conversation history
- Document task detection and suggestion features and include unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab9e1780c48332b7a28f4010934530