### PR TITLE
Add NLP-based intent and sentiment classification

### DIFF
--- a/migrations/versions/0002_add_intent_sentiment.py
+++ b/migrations/versions/0002_add_intent_sentiment.py
@@ -1,0 +1,26 @@
+"""add intent and sentiment columns
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-06-01
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('Chat') as batch_op:
+        batch_op.add_column(sa.Column('intent', sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column('sentiment', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('Chat') as batch_op:
+        batch_op.drop_column('intent')
+        batch_op.drop_column('sentiment')

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -7,8 +7,15 @@ import app
 
 
 def test_categorize_message():
-    assert app.categorize_message("Is this working?") == "question"
-    assert app.categorize_message("All good") == "statement"
+    meta = app.categorize_message("Is this working?")
+    assert meta["intent"] == "question"
+    assert meta["sentiment"] == "neutral"
+    meta = app.categorize_message("Please review the code")
+    assert meta["intent"] == "task"
+    meta = app.categorize_message("I love this")
+    assert meta["sentiment"] == "positive"
+    meta = app.categorize_message("This is terrible")
+    assert meta["sentiment"] == "negative"
 
 
 def test_summarize_messages():
@@ -68,6 +75,65 @@ class FakeConnection:
 @contextmanager
 def fake_db(data):
     yield FakeConnection(data)
+
+
+def test_process_new_messages(monkeypatch):
+    data = {"Chat": [
+        {"id": 1, "message": "Can you help me?", "intent": None, "sentiment": None},
+        {"id": 2, "message": "I hate bugs", "intent": None, "sentiment": None},
+    ]}
+
+    class ClassifyCursor:
+        def __init__(self, data):
+            self.data = data
+            self.result = []
+
+        def execute(self, sql, params=None):
+            sql = sql.strip().lower()
+            if sql.startswith("select id, message from chat where intent is null"):
+                self.result = [
+                    (m["id"], m["message"])
+                    for m in self.data["Chat"]
+                    if m.get("intent") is None or m.get("sentiment") is None
+                ][:50]
+            elif sql.startswith("update chat set intent"):
+                intent, sentiment, category, mid = params
+                for m in self.data["Chat"]:
+                    if m["id"] == mid:
+                        m["intent"] = intent
+                        m["sentiment"] = sentiment
+                        m["category"] = category
+
+        def fetchall(self):
+            return self.result
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class ClassifyConnection:
+        def __init__(self, data):
+            self.data = data
+
+        def cursor(self):
+            return ClassifyCursor(self.data)
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+    @contextmanager
+    def fake_db_local(data):
+        yield ClassifyConnection(data)
+
+    monkeypatch.setattr(app, "db", lambda: fake_db_local(data))
+    app.process_new_messages()
+    assert data["Chat"][0]["intent"] == "question"
+    assert data["Chat"][1]["sentiment"] == "negative"
 
 
 def test_process_summary_tasks(monkeypatch):


### PR DESCRIPTION
## Summary
- Expand message categorization to use myGPT when available with heuristic fallback
- Store intent and sentiment classifications in Chat table and migration
- Populate classification fields during background message processing
- Test categorization and processing across multiple message types

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abfe73c8a8833295d1ae30415a70ec