### PR TITLE
Add webhook endpoint and update ingestors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `python main.py` to launch both servers simultaneously.
 ## Message Ingestors
 
 Modules under `ingestors/` retrieve messages from external platforms and push
-normalized content to the FastAPI `POST /messages` endpoint.
+normalized content to the FastAPI `POST /webhook` endpoint.
 
 | Module | Purpose | Required Credentials |
 |-------|---------|----------------------|
@@ -64,7 +64,7 @@ python -m ingestors.whatsapp
 The FastAPI service now runs a background scheduler powered by
 `APScheduler`. Two periodic jobs are registered on startup:
 
-1. **Message categorization** – new messages inserted via `/messages`
+1. **Message categorization** – new messages inserted via `/webhook`
    are checked for a simple question/statement category and the result is
    stored in the `Chat.category` column.
 2. **Conversation summarization** – pending tasks stored in the
@@ -76,7 +76,7 @@ and the scheduler will fill in the `summary` field once processed.
 
 ## Follow-up Task Detection
 
-Incoming messages sent to `POST /messages` are now scanned for follow-up
+Incoming messages sent to `POST /webhook` are now scanned for follow-up
 phrases such as "please", "can you" or "todo". Detected tasks are stored
 in a dedicated `followup_tasks` table with a default `pending` status so
 they can be reviewed or acted on later.

--- a/app.py
+++ b/app.py
@@ -384,7 +384,7 @@ def create_message(msg: MessageIn):
 
 @app.post("/webhook", response_model=MessageOut, dependencies=[Depends(require_api_key)])
 def webhook_ingest(msg: MessageIn):
-    """Receive real-time webhooks and store messages."""
+    """Accept normalized message payloads and store via create_message."""
     return create_message(msg)
 
 

--- a/description.md
+++ b/description.md
@@ -20,7 +20,7 @@ Her fra kan man få opsumering på forskellige tråde, automatisk oprettet opgav
 
 ### FastAPI Service Development
 
-- Implement endpoints: `/health`, `/messages`, `/search`, `/conversations`.
+- Implement endpoints: `/health`, `/webhook`, `/search`, `/conversations`.
 - Add API-key authentication middleware.
 - Launch background jobs for message categorization and summary processing.
 - Integrate embedding/vector lookup for context search.
@@ -35,7 +35,7 @@ Her fra kan man få opsumering på forskellige tråde, automatisk oprettet opgav
 ### Message Ingestion Modules
 
 - Create adapters for Messenger, WhatsApp, Outlook, SMS, Aula, etc.
-- Normalize each platform’s messages and forward to the FastAPI `/messages` endpoint.
+- Normalize each platform’s messages and forward to the FastAPI `/webhook` endpoint.
 - Handle credentials, webhooks, and periodic polling logic for each platform.
 
 ### Classification & Indexing

--- a/ingestors/aula.py
+++ b/ingestors/aula.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized Aula message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
-    url = f"{API_BASE}/messages"
+    url = f"{API_BASE}/webhook"
     try:
         requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
     except Exception as exc:

--- a/ingestors/messenger.py
+++ b/ingestors/messenger.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
-    url = f"{API_BASE}/messages"
+    url = f"{API_BASE}/webhook"
     try:
         requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
     except Exception as exc:

--- a/ingestors/outlook.py
+++ b/ingestors/outlook.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized Outlook message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
-    url = f"{API_BASE}/messages"
+    url = f"{API_BASE}/webhook"
     try:
         requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
     except Exception as exc:

--- a/ingestors/sms.py
+++ b/ingestors/sms.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized SMS message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
-    url = f"{API_BASE}/messages"
+    url = f"{API_BASE}/webhook"
     try:
         requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
     except Exception as exc:

--- a/ingestors/whatsapp.py
+++ b/ingestors/whatsapp.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized WhatsApp message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
-    url = f"{API_BASE}/messages"
+    url = f"{API_BASE}/webhook"
     try:
         requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
     except Exception as exc:

--- a/test.py
+++ b/test.py
@@ -157,7 +157,7 @@ class TestFastAPIServer:
             "app": "TestApp"
         }
         store_response = requests.post(
-            f"{FASTAPI_SERVER_URL}/messages", json=message_payload, headers=HEADERS
+            f"{FASTAPI_SERVER_URL}/webhook", json=message_payload, headers=HEADERS
         )
         assert store_response.status_code == 200
         stored_info = store_response.json()

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,77 @@
+import os
+import sys
+from contextlib import contextmanager
+from datetime import datetime
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+from fastapi.testclient import TestClient
+
+
+class FakeCursor:
+    def __init__(self, data):
+        self.data = data
+        self.fetchone_result = None
+
+    def execute(self, sql, params=None):
+        sql = sql.strip().lower()
+        if sql.startswith("insert into chat"):
+            _id = len(self.data["Chat"]) + 1
+            sender, app_name, message, conv_id = params
+            self.data["Chat"].append({
+                "id": _id,
+                "conversation_id": conv_id,
+                "sender": sender,
+                "app": app_name,
+                "message": message,
+            })
+            self.fetchone_result = (_id, conv_id, datetime.utcnow())
+
+    def fetchone(self):
+        return self.fetchone_result
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, data):
+        self.data = data
+
+    def cursor(self):
+        return FakeCursor(self.data)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+@contextmanager
+def fake_db(data):
+    yield FakeConnection(data)
+
+
+def test_webhook_persists_message(monkeypatch):
+    data = {"Chat": []}
+
+    def _fake_db():
+        return fake_db(data)
+
+    monkeypatch.setattr(app, "db", _fake_db)
+    client = TestClient(app.app)
+    payload = {
+        "sender": "alice",
+        "app": "sms",
+        "message": "hello",
+        "conversation_id": "1",
+    }
+    resp = client.post("/webhook", json=payload, headers={"X-API-Key": app.API_KEY_EXPECTED})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == 1
+    assert len(data["Chat"]) == 1
+    assert data["Chat"][0]["message"] == "hello"


### PR DESCRIPTION
## Summary
- add `/webhook` endpoint forwarding normalized messages to `create_message`
- forward messages from ingestors to `/webhook`
- document webhook usage and add test verifying persistence

## Testing
- `./.venv/bin/pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abfe657de88332ad9421587fcf9224