### PR TITLE
Use Alembic for database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ environment variables `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` and
 `DB_NAME`. An API key is expected in the `x-api-key` header; override the
 default using the `API_KEY` environment variable.
 
+## Database Migrations
+
+Alembic manages schema changes. Apply pending migrations with:
+
+```bash
+alembic upgrade head
+```
+
+To create a new migration after modifying the schema:
+
+```bash
+alembic revision -m "description of change"
+```
+
+The FastAPI service automatically runs `alembic upgrade head` on startup
+to ensure the database is up to date.
+
 ## API Key
 
 The FastAPI service requires a simple header-based API key. For development

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,5 +1,7 @@
 [alembic]
 script_location = migrations
+# Default database URL; overridden in code via Alembic Config if needed
+sqlalchemy.url = postgresql://postgres:postgres@127.0.0.1:54322/postgres
 
 [loggers]
 keys = root,sqlalchemy,alembic

--- a/migrations/versions/0002_initial_tables.py
+++ b/migrations/versions/0002_initial_tables.py
@@ -1,0 +1,51 @@
+"""create chat and task tables
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2024-05-26
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0002'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'Chat',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('sender', sa.Text, nullable=False),
+        sa.Column('app', sa.Text, nullable=False),
+        sa.Column('message', sa.Text, nullable=False),
+        sa.Column('conversation_id', sa.Text, nullable=True),
+        sa.Column('contact_id', sa.Integer, sa.ForeignKey('contacts.id'), nullable=True),
+        sa.Column('category', sa.Text, nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()')),
+    )
+    op.create_table(
+        'summary_tasks',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('conversation_id', sa.Text, nullable=False),
+        sa.Column('status', sa.Text, nullable=False, server_default='pending'),
+        sa.Column('summary', sa.Text, nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()')),
+    )
+    op.create_table(
+        'followup_tasks',
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column('conversation_id', sa.Text, nullable=False),
+        sa.Column('task', sa.Text, nullable=False),
+        sa.Column('status', sa.Text, nullable=False, server_default='pending'),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()')),
+    )
+
+
+def downgrade():
+    op.drop_table('followup_tasks')
+    op.drop_table('summary_tasks')
+    op.drop_table('Chat')


### PR DESCRIPTION
## Summary
- configure Alembic with database URL in `alembic.ini`
- add initial migrations for `Chat`, `summary_tasks`, and `followup_tasks` tables
- remove manual schema creation and document migration workflow in README

## Testing
- `alembic upgrade head --sql`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abfe62d4f08332aae92909a5ef9b71