### PR TITLE
Improve conversation summarization and add comprehensive tests

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -19,18 +19,24 @@ def test_categorize_message():
 
 
 def test_summarize_messages(monkeypatch):
-    msgs = ["Hello", "How are you?", "Goodbye"]
+    msgs = [
+        {"sender": "A", "message": "Hello"},
+        {"sender": "B", "message": "How are you?"},
+        {"sender": "A", "message": "Goodbye"},
+    ]
 
     class FakeAPI:
         def generate_test_response(self, prompt: str):
+            assert "A: Hello" in prompt
+            assert "B: How are you?" in prompt
+            assert "A: Goodbye" in prompt
             return {
-                "response": "A friendly greeting and inquiry about well-being followed by a farewell."
+                "response": "A friendly greeting and inquiry about well-being followed by a farewell.",
             }
 
     monkeypatch.setattr(app, "myGPTAPI", FakeAPI)
     summary = app.summarize_messages(msgs)
     assert summary == "A friendly greeting and inquiry about well-being followed by a farewell."
-    assert summary != "Hello ... Goodbye"
 
 
 class FakeCursor:
@@ -46,10 +52,12 @@ class FakeCursor:
                 for t in self.data["summary_tasks"]
                 if t["status"] == "pending"
             ]
-        elif sql.startswith("select message from chat"):
+        elif sql.startswith("select sender, message from chat"):
             conv_id = params[0]
             self.result = [
-                (m["message"],) for m in self.data["Chat"] if m["conversation_id"] == conv_id
+                (m["sender"], m["message"])
+                for m in self.data["Chat"]
+                if m["conversation_id"] == conv_id
             ]
         elif sql.startswith("update summary_tasks set summary"):
             summary, tid = params
@@ -154,8 +162,8 @@ def test_process_new_messages(monkeypatch):
 def test_process_summary_tasks(monkeypatch):
     data = {
         "Chat": [
-            {"id": 1, "conversation_id": "1", "message": "Hello"},
-            {"id": 2, "conversation_id": "1", "message": "How are you?"},
+            {"id": 1, "conversation_id": "1", "sender": "Alice", "message": "Hello"},
+            {"id": 2, "conversation_id": "1", "sender": "Bob", "message": "How are you?"},
         ],
         "summary_tasks": [
             {"id": 1, "conversation_id": "1", "status": "pending", "summary": None}
@@ -175,5 +183,4 @@ def test_process_summary_tasks(monkeypatch):
     task = data["summary_tasks"][0]
     assert task["status"] == "completed"
     assert task["summary"] == "Hello and a check-in before goodbye."
-    assert task["summary"] != "Hello ... How are you?"
 

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -1,0 +1,77 @@
+from contextlib import contextmanager
+
+import app
+
+
+def test_long_conversation_summary(monkeypatch):
+    messages = [
+        {"sender": "User", "message": f"Message {i}"} for i in range(20)
+    ]
+    messages[0]["message"] = "We need to finish the project"
+    messages[10]["message"] = "The deadline is Friday"
+    messages[-1]["message"] = "Let's prepare a presentation"
+
+    class FakeAPI:
+        def generate_test_response(self, prompt: str):
+            assert "We need to finish the project" in prompt
+            assert "The deadline is Friday" in prompt
+            assert "Let's prepare a presentation" in prompt
+            return {
+                "response": "Project needs completion with deadline Friday and a presentation planned."
+            }
+
+    monkeypatch.setattr(app, "myGPTAPI", FakeAPI)
+    summary = app.summarize_messages(messages)
+    assert "project" in summary.lower()
+    assert "deadline" in summary.lower()
+    assert "presentation" in summary.lower()
+
+
+def test_summarize_conversation_api_error(monkeypatch):
+    data = {
+        "Chat": [
+            {"id": 1, "conversation_id": "1", "sender": "A", "message": "Hello"},
+            {"id": 2, "conversation_id": "1", "sender": "B", "message": "Bye"},
+        ]
+    }
+
+    class ErrorAPI:
+        def generate_test_response(self, prompt: str):
+            raise RuntimeError("boom")
+
+    class Cursor:
+        def __init__(self, data):
+            self.data = data
+        def execute(self, sql, params=None):
+            conv_id = params[0]
+            self.result = [
+                (m["sender"], m["message"])
+                for m in self.data["Chat"]
+                if m["conversation_id"] == conv_id
+            ]
+        def fetchall(self):
+            return self.result
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    class Conn:
+        def __init__(self, data):
+            self.data = data
+        def cursor(self):
+            return Cursor(self.data)
+        def commit(self):
+            pass
+        def rollback(self):
+            pass
+
+    @contextmanager
+    def fake_db(data):
+        yield Conn(data)
+
+    monkeypatch.setattr(app, "db", lambda: fake_db(data))
+    monkeypatch.setattr(app, "myGPTAPI", ErrorAPI)
+    summary = app.summarize_conversation("1")
+    assert summary == "Hello ... Bye"
+


### PR DESCRIPTION
## Summary
- Build detailed prompts with full conversation history and call `myGPTAPI` for summaries
- Summarize conversations with graceful fallback when myGPT fails
- Add tests covering long conversations and API error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7fc372ac8332afe2a7e28d459f3a