### PR TITLE
Add simple client CLI and tests

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,27 @@
+# Client CLI
+
+A minimal command-line interface for interacting with the myGPT API.
+
+## Setup
+
+Ensure the API server from this repository is running and accessible. Set the
+API base URL and key as environment variables if needed:
+
+```bash
+export API_BASE_URL="http://localhost:8000"
+export API_KEY="your-secret-key"
+```
+
+## Usage
+
+Run the CLI with Python. Examples:
+
+```bash
+python client/cli.py conversations            # List conversation IDs
+python client/cli.py summary 123              # Show summary for conversation 123
+python client/cli.py tasks                    # List all summary tasks
+python client/cli.py suggest 123 --limit 2    # Suggest replies for conversation 123
+```
+
+Each command accepts optional `--base-url` and `--api-key` arguments to override
+the environment variables.

--- a/client/cli.py
+++ b/client/cli.py
@@ -1,0 +1,94 @@
+import argparse
+import os
+from typing import List
+
+import requests
+
+DEFAULT_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
+DEFAULT_API_KEY = os.getenv("API_KEY", "")
+
+
+def _headers(api_key: str) -> dict:
+    return {"X-API-KEY": api_key} if api_key else {}
+
+
+def _get(base_url: str, api_key: str, path: str):
+    resp = requests.get(f"{base_url}{path}", headers=_headers(api_key))
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _post(base_url: str, api_key: str, path: str, payload: dict):
+    resp = requests.post(
+        f"{base_url}{path}", json=payload, headers=_headers(api_key)
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def list_conversations(base_url: str, api_key: str) -> List[str]:
+    tasks = _get(base_url, api_key, "/tasks")
+    ids = sorted({t["conversation_id"] for t in tasks})
+    return ids
+
+
+def get_summary(conversation_id: str, base_url: str, api_key: str) -> str:
+    tasks = _get(base_url, api_key, "/tasks")
+    for t in tasks:
+        if t["conversation_id"] == conversation_id and t.get("summary"):
+            return t["summary"]
+    return ""
+
+
+def list_tasks(base_url: str, api_key: str):
+    return _get(base_url, api_key, "/tasks")
+
+
+def request_suggestions(
+    conversation_id: str, base_url: str, api_key: str, limit: int = 3
+) -> List[str]:
+    data = _post(
+        base_url, api_key, "/suggestions", {"conversation_id": conversation_id, "limit": limit}
+    )
+    return data.get("suggestions", [])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="myGPT API client")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--api-key", default=DEFAULT_API_KEY)
+
+    sub = parser.add_subparsers(dest="cmd")
+    sub.add_parser("conversations", help="List conversation IDs")
+
+    sp_sum = sub.add_parser("summary", help="Show summary for a conversation")
+    sp_sum.add_argument("conversation_id")
+
+    sub.add_parser("tasks", help="List tasks")
+
+    sp_sug = sub.add_parser("suggest", help="Request reply suggestions")
+    sp_sug.add_argument("conversation_id")
+    sp_sug.add_argument("--limit", type=int, default=3)
+
+    args = parser.parse_args()
+    base_url = args.base_url
+    api_key = args.api_key
+
+    if args.cmd == "conversations":
+        for cid in list_conversations(base_url, api_key):
+            print(cid)
+    elif args.cmd == "summary":
+        summary = get_summary(args.conversation_id, base_url, api_key)
+        print(summary or "No summary available")
+    elif args.cmd == "tasks":
+        for t in list_tasks(base_url, api_key):
+            print(f"{t['id']} {t['conversation_id']} {t['status']}")
+    elif args.cmd == "suggest":
+        for s in request_suggestions(args.conversation_id, base_url, api_key, args.limit):
+            print(f"- {s}")
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client_cli.py
+++ b/tests/test_client_cli.py
@@ -1,0 +1,35 @@
+import sys
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+# Ensure the project root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from client import cli
+
+
+def _mock_response(data):
+    resp = Mock()
+    resp.json.return_value = data
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_list_conversations():
+    data = [
+        {"conversation_id": "1", "id": 1, "status": "completed", "summary": "Hi"},
+        {"conversation_id": "2", "id": 2, "status": "pending", "summary": None},
+        {"conversation_id": "1", "id": 3, "status": "completed", "summary": "Bye"},
+    ]
+    with patch("client.cli.requests.get", return_value=_mock_response(data)) as mock_get:
+        ids = cli.list_conversations("http://example", "key")
+        assert ids == ["1", "2"]
+        mock_get.assert_called_once()
+
+
+def test_request_suggestions():
+    payload = {"suggestions": ["Hello", "How are you?"]}
+    with patch("client.cli.requests.post", return_value=_mock_response(payload)) as mock_post:
+        suggestions = cli.request_suggestions("1", "http://example", "key", limit=2)
+        assert suggestions == ["Hello", "How are you?"]
+        mock_post.assert_called_once()


### PR DESCRIPTION
## Summary
- add minimal `client/cli.py` to list tasks, summaries and suggestions
- document client setup and usage
- test CLI helpers for conversation listing and suggestions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac7fcfba2c8332aaa341c8af951717