### PR TITLE
Add retry logging for ingestor webhooks

### DIFF
--- a/ingestors/aula.py
+++ b/ingestors/aula.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List
 
 import requests
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
 from . import resolve_contact_id
 
 API_BASE = os.getenv("APP_API_URL", "http://127.0.0.1:8000")
@@ -13,6 +14,16 @@ AULA_TOKEN = os.getenv("AULA_TOKEN")
 log = logging.getLogger(__name__)
 
 
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=before_sleep_log(log, logging.WARNING),
+)
+def _post_with_retry(url: str, msg: Dict[str, Any], headers: Dict[str, str]):
+    return requests.post(url, json=msg, headers=headers, timeout=10)
+
+
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized Aula message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
@@ -20,7 +31,7 @@ def _forward(msg: Dict[str, Any]) -> None:
     url = f"{API_BASE}/webhook"
 
     try:
-        requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
+        _post_with_retry(url, msg, headers).raise_for_status()
     except Exception as exc:
         log.error("Failed forwarding Aula message: %s", exc)
 

--- a/ingestors/outlook.py
+++ b/ingestors/outlook.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List
 
 import requests
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
 from . import resolve_contact_id
 
 API_BASE = os.getenv("APP_API_URL", "http://127.0.0.1:8000")
@@ -13,6 +14,16 @@ OUTLOOK_USER_ID = os.getenv("OUTLOOK_USER_ID", "me")
 log = logging.getLogger(__name__)
 
 
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=before_sleep_log(log, logging.WARNING),
+)
+def _post_with_retry(url: str, msg: Dict[str, Any], headers: Dict[str, str]):
+    return requests.post(url, json=msg, headers=headers, timeout=10)
+
+
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized Outlook message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
@@ -20,7 +31,7 @@ def _forward(msg: Dict[str, Any]) -> None:
     url = f"{API_BASE}/webhook"
 
     try:
-        requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
+        _post_with_retry(url, msg, headers).raise_for_status()
     except Exception as exc:
         log.error("Failed forwarding Outlook message: %s", exc)
 

--- a/ingestors/sms.py
+++ b/ingestors/sms.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List
 
 import requests
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
 from . import resolve_contact_id
 
 API_BASE = os.getenv("APP_API_URL", "http://127.0.0.1:8000")
@@ -13,6 +14,16 @@ TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
 log = logging.getLogger(__name__)
 
 
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=before_sleep_log(log, logging.WARNING),
+)
+def _post_with_retry(url: str, msg: Dict[str, Any], headers: Dict[str, str]):
+    return requests.post(url, json=msg, headers=headers, timeout=10)
+
+
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized SMS message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
@@ -20,7 +31,7 @@ def _forward(msg: Dict[str, Any]) -> None:
     url = f"{API_BASE}/webhook"
 
     try:
-        requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
+        _post_with_retry(url, msg, headers).raise_for_status()
     except Exception as exc:
         log.error("Failed forwarding SMS message: %s", exc)
 

--- a/ingestors/whatsapp.py
+++ b/ingestors/whatsapp.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Dict, List
 
 import requests
+from tenacity import before_sleep_log, retry, stop_after_attempt, wait_exponential
 from . import resolve_contact_id
 
 API_BASE = os.getenv("APP_API_URL", "http://127.0.0.1:8000")
@@ -13,6 +14,16 @@ WHATSAPP_PHONE_NUMBER_ID = os.getenv("WHATSAPP_PHONE_NUMBER_ID")
 log = logging.getLogger(__name__)
 
 
+@retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=10),
+    before_sleep=before_sleep_log(log, logging.WARNING),
+)
+def _post_with_retry(url: str, msg: Dict[str, Any], headers: Dict[str, str]):
+    return requests.post(url, json=msg, headers=headers, timeout=10)
+
+
 def _forward(msg: Dict[str, Any]) -> None:
     """Send a normalized WhatsApp message to the FastAPI service."""
     headers = {"X-API-KEY": API_KEY}
@@ -20,7 +31,7 @@ def _forward(msg: Dict[str, Any]) -> None:
     url = f"{API_BASE}/webhook"
 
     try:
-        requests.post(url, json=msg, headers=headers, timeout=10).raise_for_status()
+        _post_with_retry(url, msg, headers).raise_for_status()
     except Exception as exc:
         log.error("Failed forwarding WhatsApp message: %s", exc)
 

--- a/tests/test_ingestor_forward_retry.py
+++ b/tests/test_ingestor_forward_retry.py
@@ -1,0 +1,32 @@
+import importlib
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+
+@pytest.mark.parametrize(
+    "module_name, app_name",
+    [
+        ("ingestors.messenger", "Messenger"),
+        ("ingestors.sms", "SMS"),
+        ("ingestors.whatsapp", "WhatsApp"),
+        ("ingestors.outlook", "Outlook"),
+        ("ingestors.aula", "Aula"),
+    ],
+)
+
+def test_forward_retries_and_logs(monkeypatch, caplog, module_name, app_name):
+    mod = importlib.import_module(module_name)
+    post = MagicMock(side_effect=requests.RequestException("boom"))
+    monkeypatch.setattr(mod.requests, "post", post)
+
+    with caplog.at_level(logging.WARNING):
+        mod._forward({"sender": "s", "message": "m", "app": "app", "conversation_id": "1"})
+
+    assert post.call_count == 3
+    warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warning_logs) == 2
+    error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert error_logs and f"Failed forwarding {app_name}" in error_logs[0].message


### PR DESCRIPTION
## Summary
- add tenacity-based retries around ingestor HTTP forwards with exponential backoff and warning logs
- test retry behavior to ensure warnings and final errors are logged after repeated failures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac803953cc83328a136304a896ed3f